### PR TITLE
launch_quota.total_quota not total_pods

### DIFF
--- a/binderhub/health.py
+++ b/binderhub/health.py
@@ -251,7 +251,7 @@ class KubernetesHealthHandler(HealthHandler):
         n_user_pods = len(user_pods)
         n_build_pods = len(build_pods)
 
-        quota = self.settings["launch_quota"].total_pods
+        quota = self.settings["launch_quota"].total_quota
         total_pods = n_user_pods + n_build_pods
         usage = {
             "total_pods": total_pods,


### PR DESCRIPTION
Fix for https://github.com/jupyterhub/binderhub/pull/1682#issuecomment-1530106672
(and therefore https://github.com/jupyterhub/mybinder.org-deploy/issues/2617)

This should be `total_quota` since `LaunchQuota` is platform agnostic
https://github.com/jupyterhub/binderhub/blob/0c3d8b23d396f1d0d276605356c8c329b2cc1376/binderhub/quota.py#L43-L54
